### PR TITLE
Add initial README for Kotlin project

### DIFF
--- a/hangman/Kotlin/README.md
+++ b/hangman/Kotlin/README.md
@@ -1,0 +1,5 @@
+To compile, you need Kotlin installed.
+
+* ```kotlinc hangman.kt -include-runtime -d hangman.jar```
+
+To run, on the command line run the command ```java -jar hangman.jar```.


### PR DESCRIPTION
This fixes #35 by adding an initial README